### PR TITLE
fix `read_interface_token` for A10

### DIFF
--- a/binder_trace/binder_trace/parcel.py
+++ b/binder_trace/binder_trace/parcel.py
@@ -177,6 +177,8 @@ class ParcelParser:
         if constants.ANDROID_VERSION >= 11:
             self.parse_field("Work Source UID", "uint32", self.readUint32, parent)
             self.parse_field("Version Header", "uint32", self.readUint32, parent)
+        elif constants.ANDROID_VERSION == 10:
+            self.parse_field("Work Source UID", "uint32", self.readUint32, parent)
         self.parse_field("Token Descriptor", "string", self.readString16, parent)
         self.align4()
 


### PR DESCRIPTION
fix for Android 10
see these:
https://cs.android.com/android/platform/superproject/+/android-cts-9.0_r20:frameworks/native/libs/binder/Parcel.cpp;l=613
https://cs.android.com/android/platform/superproject/+/android-10.0.0_r19:frameworks/native/libs/binder/Parcel.cpp;l=649