### PR TITLE
Remove unused import causing incompatibility with Python 3.12

### DIFF
--- a/binder_trace/binder_trace/parsedParcel.py
+++ b/binder_trace/binder_trace/parsedParcel.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from asyncore import read
 from dataclasses import dataclass
 from enum import Enum
 from http.client import INSUFFICIENT_STORAGE


### PR DESCRIPTION
fixes #32 